### PR TITLE
Fix molding for Granges with truncated gaps

### DIFF
--- a/R/mold-method.R
+++ b/R/mold-method.R
@@ -11,6 +11,13 @@ setMethod("mold", c("eSet"), function(data){
 
 setMethod("mold", c("GRanges"), function(data){
   names(data) <- NULL
+  ## Truncated ranges will have a copy of the original ranges
+  ## this copy should be removed when molding
+  originalranges <-  colnames(mcols(rangescr)) %in% ".ori"
+  if(any(originalranges)){
+    mcols(rangescr)[originalranges] <- NULL
+  }
+ 
   df <- as.data.frame(data)
   df$midpoint <- (df$start+df$end)/2
   df


### PR DESCRIPTION
When trying to use ggbio to plot a Gene model with truncated gaps from and ensdb object an error is thrown:
```
library(EnsDb.Hsapiens.v86)
ensdb <- EnsDb.Hsapiens.v86

autoplot(ensdb, AnnotationFilter(~gene_id == "ENSG00000140553"), truncate.gaps=T)

Output:

Fetching data...OK
Parsing exons...OK
Defining introns...OK
Defining UTRs...OK
Defining CDS...OK
aggregating...
truncating ...
Done
Error in data.frame(seqnames = as.factor(seqnames(x)), start = start(x),  : 
  duplicate row.names: ENSE00001517981, ENSE00001517979, ENSE00001517976, ENSE00001915297, ENSE00003676577, ENSE00003573421, ENSE00003623244, ENSE00001815164, ENSE00003486472, ENSE00003569062, ENSE00003631334, ENSE00003662314, ENSE00003672295, ENSE00003562898, ENSE00003614752, ENSE00001307423, ENSE00001313350, ENSE00000943755, ENSE00000943756, ENSE00003650599, ENSE00001108269, ENSE00001108262, ENSE00003570330, ENSE00003662197, ENSE00003555199, ENSE00003606474, ENSE00003606872, ENSE00003692253, ENSE00003508904, ENSE00003680191, ENSE00003596184, ENSE00003581338, ENSE00003686068, ENST00000394275, ENST00000418476, ENST00000461266, ENST00000471780, ENST00000480470, ENST00000486253, ENST00000487875, ENST00000495068, ENST00000497152, ENST00000553671, ENST00000556482, ENST00000556704, ENST00000557212

```

This error happens when parsing the GRanges to a data frame because the original GRanges object is still present as a metadata column of the truncated Granges. I am removing the original Granges before molding.

Please review